### PR TITLE
Fix infinite loop

### DIFF
--- a/Geofirestore/Classes/Geofirestore.swift
+++ b/Geofirestore/Classes/Geofirestore.swift
@@ -468,17 +468,15 @@ public class GFSQuery {
 
     internal func reset() {
         if !queries.isEmpty {
-            for query: GFGeoHashQuery? in queries {
+            for query in queries {
                 var handle: GFSGeoHashQueryListener?
-                if let aQuery = query {
-                    handle = self.handles[aQuery]
-                    if handle == nil {
-                        NSException.raise(.internalInconsistencyException, format: "Wanted to remove a geohash query that was not registered!", arguments: getVaList(["nil"]))
-                    }
-                    handle?.childAddedListener?.remove()
-                    handle?.childChangedListener?.remove()
-                    handle?.childRemovedListener?.remove()
+                handle = self.handles[query]
+                if handle == nil {
+                    NSException.raise(.internalInconsistencyException, format: "Wanted to remove a geohash query that was not registered!", arguments: getVaList(["nil"]))
                 }
+                handle?.childAddedListener?.remove()
+                handle?.childChangedListener?.remove()
+                handle?.childRemovedListener?.remove()
                 
             }
         }


### PR DESCRIPTION
When I called removeAllObservers() and/or removeObserver(withHandle: GFSQueryHandle) on GFSQuery, It fall into infinite loop on reset() function.
When for loop started, query variable keep getting nil and never exit from loop.
So, I fixed that issue. 
Please check my code and merge it if it look okay. 